### PR TITLE
Setup initial workflows

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,6 +1,10 @@
 name: Java CI on push
 
-on: [push]
+on:
+  push:
+    branches:
+      - dev/*
+      - development
 
 jobs:
   build:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - dev/*
-      - development
+      - dev
 
 jobs:
   build:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,24 @@
+name: Java CI on push
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 14
+        uses: actions/setup-java@v1
+        with:
+          java-version: 14
+
+      - name: Cache the Maven packages to speed up build
+        uses: actions/cache@v1
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+
+      - name: Build with Maven
+        run: mvn -B package --file pom.xml


### PR DESCRIPTION
Creates a main workflow "Java CI on push", that builds project via Maven and caches dependencies for faster build and test.

Workflow is triggered for branches:
- `dev/*` - all feature branches, starting with `dev/`
- `development` - development branch

This workflow should be enhanced further.